### PR TITLE
Added keep_alive argument and fixed warnings

### DIFF
--- a/examples/publish_wait.rs
+++ b/examples/publish_wait.rs
@@ -10,12 +10,12 @@ fn as_millis(d: Duration) -> f64 {
 
 const TIMEOUT: i32 = 300;
 
-fn run() -> Result<(),Box<std::error::Error>> {
+fn run() -> Result<(),Box<dyn std::error::Error>> {
     let m = Mosquitto::new("test");
 
     let t = Instant::now();
 
-    m.connect_wait("localhost",1883,TIMEOUT)?;
+    m.connect_wait("localhost",1883,5,TIMEOUT)?;
     m.publish_wait("/bonzo/dog",b"hello dolly",2,false,TIMEOUT)?;
     m.publish_wait("/bonzo/cat",b"meeeaaaww",2,false,TIMEOUT)?;
     println!("elapsed {:.2} msec",as_millis(t.elapsed()));

--- a/examples/self-publish-receive-many.rs
+++ b/examples/self-publish-receive-many.rs
@@ -5,7 +5,7 @@ use std::thread;
 fn run() -> mosq::Result<()> {
     let m = Mosquitto::new("test");
 
-    m.connect_wait("localhost",1883,300)?;
+    m.connect_wait("localhost",1883,5,300)?;
     let bilbo = m.subscribe("bilbo/#",1)?;
 
     let mt = m.clone();

--- a/examples/self-publish.rs
+++ b/examples/self-publish.rs
@@ -5,7 +5,7 @@ use std::{thread, time};
 fn main() {
     let m = Mosquitto::new("test");
     
-    m.connect("localhost",1883).expect("can't connect");
+    m.connect("localhost",1883,5).expect("can't connect");
     m.subscribe("bilbo/#",1).expect("can't subscribe to bonzo");
     
     let mt = m.clone();

--- a/examples/subscribe-and-listen.rs
+++ b/examples/subscribe-and-listen.rs
@@ -6,7 +6,7 @@ fn main() {
 
     m.will_set("test/will",b"finished!",0,false).expect("can't set will");
 
-    m.connect("localhost",1883).expect("can't connect");
+    m.connect("localhost",1883,5).expect("can't connect");
     let bonzo = m.subscribe("bonzo/#",0).expect("can't subscribe to bonzo");
     let frodo = m.subscribe("frodo/#",0).expect("can't subscribe to frodo");
 

--- a/examples/verify-publish.rs
+++ b/examples/verify-publish.rs
@@ -3,10 +3,10 @@ use mosq::Mosquitto;
 
 use std::error::Error;
 
-fn go() -> Result<(),Box<Error>> {
+fn go() -> Result<(),Box<dyn Error>> {
     let m = Mosquitto::new("test");
 
-    m.connect("localhost",1883)?;
+    m.connect("localhost",1883,5)?;
 
     // publish and get a message id
     let our_mid = m.publish("bonzo/dog","hello dolly".as_bytes(), 2, false)?;

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ use std::{thread, time};
 fn main() {
     let m = Mosquitto::new("test");
 
-    m.connect("localhost",1883).expect("can't connect");
+    m.connect("localhost",1883,5).expect("can't connect");
     m.subscribe("bilbo/#",1).expect("can't subscribe to bonzo");
 
     let mt = m.clone();


### PR DESCRIPTION
Added keep_alive argument to connect(), as the previous implementation failed with libmosquitto>1.6.8 due to changes in the libmosquitto behavoiur for mosquitto_connect
Fixed various rust compiler warnings